### PR TITLE
Rebuilt lablel command, removed create_repo from main

### DIFF
--- a/Label.h
+++ b/Label.h
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <fstream>
+#include <experimental/filesystem>
+#include <stdio.h>
+
+void label(std::string manifest_path, std::string label_name) {
+
+	std::string _manifest_path = manifest_path + "\\manifest.txt";
+	std::string _label_name = manifest_path + "\\" + label_name + ".txt";
+	char f;
+	std::string new_name;
+
+	std::cout << "Has the manifest filename been changed? <y/n> \n";
+	f = std::getchar();
+	if (f == 'y') {
+		std::cout << "Enter the name of the manifest file you wish to change: \n";
+		std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+		std::getline(std::cin, new_name);
+		_manifest_path = manifest_path + "\\" + new_name + ".txt";
+	}
+
+	std::cout << "Change filename? <y/n> \n";
+	std::cin >> f;
+	if (f == 'y') {
+		std::rename(_manifest_path.c_str(), _label_name.c_str());
+	}
+	else if (f == 'n') {
+		std::ofstream manifest_file;
+		manifest_file.open(_manifest_path, std::ofstream::out | std::ofstream::app);
+		manifest_file << "\n";
+		manifest_file << "Label: " << label_name;
+		manifest_file.close();
+	}
+	else {
+		std::cout << "Invalid choice!";
+	}
+	system("pause");
+}

--- a/Source.cpp
+++ b/Source.cpp
@@ -19,39 +19,16 @@
 #include <vector>
 #include <string>
 #include <ctime>
+#include <stdio.h>
 
 #include "checksum.h"
+#include "Label.h"
 
 namespace fs = std::experimental::filesystem;
 
 
-void create_repo()
+void create_repo(std::string sourcePath, std::string targetPath)
 {
-	std::string sourcePath;
-	std::string targetPath;
-
-	std::cout << "Please enter the source path you want to copy: \n";
-
-	std::getline(std::cin, sourcePath);											//get sourcePath, includes whitespace for Windows paths
-
-	/*
-	if (!fs::is_directory(sourcePath)) {
-		std::cout << "Not a valid path \n";
-		return 1;
-	}
-	*/
-
-	std::cout << "Now enter the target path you want to create your repo: \n";
-
-	std::getline(std::cin, targetPath);											//get targetPath, includes whitespace for Windows paths
-
-	/*
-	if (!fs::is_directory(targetPath)) {
-		std::cout << "Target path does not exist. \n";
-		std::cout << "Creating directory. \n";
-		fs::create_directory(targetPath);
-	}
-	*/
 
 	time_t current_time = time(NULL);
 	//array to take in the system time and date
@@ -182,28 +159,12 @@ void create_repo()
 
 }
 
-void label() {
 
-	std::string manifest_folder;
-	std::string label;
-
-	std::cout << "Enter the repository root path to find manifest file: \n";
-	std::getline(std::cin, manifest_folder);
-	std::cout << "Enter your label: ";
-	std::getline(std::cin, label);
-
-	std::ofstream manifest_file(manifest_folder);
-	manifest_file.open(manifest_folder += "\\manifest.txt", std::ofstream::app);
-	manifest_file << label;
-	manifest_file.close();
-
-}
 
 int main() {
 
-
-	label();
-	//create_repo();
-
+	label("mypt2_repo", "Fred");
+	//create_repo("mypt2", "mypt2_repo");
+	
 	return 0;
 }


### PR DESCRIPTION
- Label command now asks user if they want to replace the filename or append the label into the manifest text file.
- Its arguments are the repository directory where the target manifest file is and a string for user defined label.
- Removed create_repo from main function into its own.
- Takes source directory and target directory as its arguments.
- Removed initial user input to specify directories.